### PR TITLE
Remove redundant depends-on list in Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,7 +2,3 @@
 (source gnu)
 
 (package-file "evil-smartparens.el")
-
-(depends-on "evil")
-(depends-on "diminish")
-(depends-on "smartparens")


### PR DESCRIPTION
These dependencies (and more) are already listed in `evil-smartparens.el`.
