### PR TITLE
Indent after a change or delete, so that indenation is preserved.

### DIFF
--- a/evil-smartparens.el
+++ b/evil-smartparens.el
@@ -159,7 +159,8 @@ list of (fn args) to pass to `apply''"
             (evil-delete new-beg new-end 'inclusive yank-handler)))
       (error (let* ((beg (evil-sp--new-beginning beg end :shrink))
                     (end (evil-sp--new-ending beg end)))
-               (evil-delete beg end type yank-handler))))))
+               (evil-delete beg end type yank-handler)))))
+	(indent-according-to-mode))
 
 (evil-define-operator evil-sp-change (beg end type register yank-handler)
   "Call `evil-change' with a balanced region"
@@ -178,7 +179,8 @@ list of (fn args) to pass to `apply''"
             (evil-change new-beg new-end 'inclusive yank-handler)))
       (error (let* ((beg (evil-sp--new-beginning beg end :shrink))
                     (end (evil-sp--new-ending beg end)))
-               (evil-change beg end type yank-handler))))))
+               (evil-change beg end type yank-handler)))))
+	(indent-according-to-mode))
 
 (evil-define-operator evil-sp-yank (beg end type register yank-handler)
   :move-point nil


### PR DESCRIPTION
In smartparens-strict-mode, when deleting or changing the whole line, if the block is unbalanced, the operation is a no-op, but the mechanics of evil-delete sets the starting point of the motion (the whole line) as the beginning of the line, and thus the unbalanced sexps get deindented.

Another fix would be to modify evil-sp--new-beginning to use the start of thecurrent sexp as the beginning of the motion. This is probably a bit smarter, as the current feature feels a bit hairy, though it works.

Without this, the following behaviour occurs: (| represents point)

``` emacs
(defun foo (bar)
    (|let ((baz (+ bar 1)))
        baz))
```

Hitting <kbd>dd</kbd> here would do nothing, but the line with the let would be deindented, same with <kbd>cc</kbd>. Similarly, doing the same at `|baz))` would delete or change baz and deindent.
