### PR TITLE
Fix about cl-lib

### DIFF
--- a/evil-smartparens.el
+++ b/evil-smartparens.el
@@ -6,7 +6,7 @@
 ;; URL: https://www.github.com/expez/evil-smartparens
 ;; Keywords: evil smartparens
 ;; Version: 0.3.0
-;; Package-Requires: ((evil "1.0") (cl-lib "0.3") (emacs "24.4") (smartparens "1.6.3"))
+;; Package-Requires: ((evil "1.0") (emacs "24.4") (smartparens "1.6.3"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -32,6 +32,7 @@
 (require 'evil)
 (require 'smartparens)
 (require 'subr-x)
+(require 'cl-lib)
 
 (defgroup evil-smartparens nil
   "`evil-mode' compat for `smartparens-mode'"
@@ -301,7 +302,7 @@ Unfortunately this only works for lisps."
           (let ((parse-state (parse-partial-sexp (point) point)))
             (when parse-state
               (let ((in-string-p (nth 3 parse-state))
-                    (depth (first parse-state)))
+                    (depth (cl-first parse-state)))
                 (if in-string-p
                     (1+ depth)
                   depth)))))))))


### PR DESCRIPTION
- Remove cl-lib from dependency header because cl-lib.el was bundled
  since Emacs 24.3 and this package requires Emacs 24.4 or higher.
- Load cl-lib.el explicitly
- Use cl-first instead of first
