### PR TITLE
Add `evil-sp-change' to 'evil-change-commands'

### DIFF
--- a/evil-smartparens.el
+++ b/evil-smartparens.el
@@ -152,6 +152,7 @@ list of (fn args) to pass to `apply''"
       (kbd "S") #'evil-sp-change-whole-line
       (kbd "X") #'evil-sp-backward-delete-char
       (kbd "x") #'evil-sp-delete-char)
+    (add-to-list 'evil-change-commands #'evil-sp-change)
     (evil-define-key 'visual evil-smartparens-mode-map
       (kbd "X") #'evil-sp-delete
       (kbd "x") #'evil-sp-delete))
@@ -198,9 +199,6 @@ list of (fn args) to pass to `apply''"
 (evil-define-operator evil-sp-change (beg end type register yank-handler)
   "Call `evil-change' with a balanced region"
   (interactive "<R><x><y>")
-  ;; #20 don't delete the space after a word
-  (when (save-excursion (goto-char end) (looking-back " " (- (point) 5)))
-    (setq end (1- end)))
   (if (or (evil-sp--override)
           (= beg end)
           (and (eq type 'block)


### PR DESCRIPTION
I recently added a new variable to evil, `evil-change-commands` which allows some evil-change settings (evil-want-change-word-to-end) to be applied to `evil-sp-change` and similar commands.

Since your function is a replacement for `evil-change`, it probably should get the same workarounds.

This should fix the dangling issues left in https://github.com/expez/evil-smartparens/issues/20.

Please see https://github.com/emacs-evil/evil/issues/916 for more information.

Let me know if you find any issues with this setup, or if you think it can be implemented in a better way.

(also, I never tested this manually, I'm relying on the test you added to verify it's working correctly). The tests seem to pass locally but not on travis.