### PR TITLE
replace obsolete sp--lisp-modes with sp-lisp-modes

### DIFF
--- a/evil-smartparens.el
+++ b/evil-smartparens.el
@@ -75,14 +75,12 @@ list of (fn args) to pass to `apply''"
 (defun evil-sp--get-endpoint-for-sp-kill-sexp ()
   (unwind-protect
       (progn
-        (push major-mode sp-navigate-consider-stringlike-sexp)
         (evil-sp--new-ending (point)
                              (or (ignore-errors
                                    (evil-sp--point-after '(sp-up-sexp 1)
                                                          '(sp-backward-down-sexp 1)))
                                  (point))
-                             :no-error))
-    (pop sp-navigate-consider-stringlike-sexp)))
+                             :no-error))))
 
 (defun evil-sp--get-endpoint-for-killing ()
   "Return the endpoint from POINT upto which `sp-kill-sexp' would kill."
@@ -301,7 +299,7 @@ proper dispatching."
   "Finds the depth at POINT using native code.
 
 Unfortunately this only works for lisps."
-  (when (memq major-mode sp--lisp-modes)
+  (when (memq major-mode sp-lisp-modes)
     (let ((point (or point (point))))
       (ignore-errors
         (save-excursion
@@ -331,11 +329,9 @@ Strings affect depth."
           (goto-char point))
         (unwind-protect
             (progn
-              (push major-mode sp-navigate-consider-stringlike-sexp)
               (while (and (not (sp-point-in-comment))
                           (ignore-errors (sp-backward-up-sexp)))
-                (cl-incf depth)))
-          (pop sp-navigate-consider-stringlike-sexp))))
+                (cl-incf depth))))))
     depth))
 
 (defun evil-sp--new-ending (beg end &optional no-error)


### PR DESCRIPTION
sp-navigate-consider-stringlike-sexp is also removed from smartparens here: https://github.com/Fuco1/smartparens/commit/a1c1ce1a4e3f325983a1c5a7b134f9fd7e91fce5
However, warnings still come up about `Search failed. This means there is unmatched expression somewhere or we are at the beginning/end of file. `

I do not know enough about how the code works to fix that.